### PR TITLE
Add snake, curtain, sine_wave, and random animations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ All top-level fields are optional. `brightness` (0-15) overrides display brightn
 ```json
 { "type": "animation", "animation": "pong", "duration_secs": 30 }
 ```
-`animation` values: `static` (TV noise), `pong` (bouncing ball with AI paddles), `matrix` or `matrix_rain` (falling columns). Unknown values default to `static`. `duration_secs` defaults to `30`; use `0` for infinite (runs until next instruction). After duration, reverts to clock. On 7-segment displays, all three animations render segment-appropriate variants.
+`animation` values: `static` (TV noise), `pong` (bouncing ball with AI paddles), `matrix` or `matrix_rain` (falling columns), `snake` (AI-driven snake chasing food on pixel; segment runs a 3-segment trail around each digit's outer perimeter — a,b,c,d,e,f,a moving right / a,f,e,d,c,b,a moving left — bouncing off the first/last digit, which drops the closing 'a'), `curtain` (pixel: fill one side → unfill same side; segment: fill digits left-to-right in 3 stages each — `e,f` → `a,d,e,f,g` → all seven — with completed digits staying lit, then unfill left-to-right peeling segments in the same order they were laid down — `a,b,c,d,g` → `b,c` → off — while digits to the right remain fully lit), `sine` / `sine_wave` / `sinewave` (pixel: scrolling sine curve; segment: one extra segment accrues across all digits per step in a,b,c,d,e,f,g order, then unrolls in the same order), `random` (pick one variant at widget start from the other six). Unknown values default to `static`. `duration_secs` defaults to `30`; use `0` for infinite (runs until next instruction). After duration, reverts to clock.
 
 **raw_pixel** — direct framebuffer control (32 bytes, one per column):
 ```json

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -147,6 +147,10 @@ impl Engine {
                             let anim_type = match animation.as_str() {
                                 "pong" => AnimationType::Pong,
                                 "matrix" | "matrix_rain" => AnimationType::MatrixRain,
+                                "snake" => AnimationType::Snake,
+                                "curtain" => AnimationType::Curtain,
+                                "sine" | "sine_wave" | "sinewave" => AnimationType::SineWave,
+                                "random" => AnimationType::Random,
                                 _ => AnimationType::Static,
                             };
                             let dur = if duration_secs == 0 {

--- a/src/widget/animation.rs
+++ b/src/widget/animation.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::collections::VecDeque;
 use std::time::Duration;
 
 use crate::display::{AnyDisplay, PixelDisplay, SegmentDisplay};
@@ -13,6 +14,10 @@ pub enum AnimationType {
     Static,
     Pong,
     MatrixRain,
+    Snake,
+    Curtain,
+    SineWave,
+    Random,
 }
 
 pub struct Animation {
@@ -35,25 +40,53 @@ impl Widget for Animation {
         let start = std::time::Instant::now();
         let mut rng = SimpleRng::new();
 
+        let resolved = if matches!(self.animation, AnimationType::Random) {
+            let pick = pick_random_type(&mut rng);
+            log::info!("random animation picked: {:?}", pick);
+            pick
+        } else {
+            self.animation.clone()
+        };
+
         match display {
             AnyDisplay::Pixel(ref mut d) => {
                 let disp = d.as_mut();
-                match self.animation {
+                match resolved {
                     AnimationType::Static => run_static(disp, cancel, &mut rng, self.duration, start),
                     AnimationType::Pong => run_pong(disp, cancel, self.duration, start),
                     AnimationType::MatrixRain => run_matrix_rain(disp, cancel, &mut rng, self.duration, start),
+                    AnimationType::Snake => run_snake(disp, cancel, &mut rng, self.duration, start),
+                    AnimationType::Curtain => run_curtain(disp, cancel, self.duration, start),
+                    AnimationType::SineWave => run_sine_wave(disp, cancel, self.duration, start),
+                    AnimationType::Random => unreachable!("random resolved above"),
                 }
             }
             AnyDisplay::Segment(ref mut d) => {
                 let disp = d.as_mut();
-                match self.animation {
+                match resolved {
                     AnimationType::Static => run_segment_static(disp, cancel, &mut rng, self.duration, start),
                     AnimationType::MatrixRain => run_segment_rain(disp, cancel, &mut rng, self.duration, start),
                     AnimationType::Pong => run_segment_pong(disp, cancel, self.duration, start),
+                    AnimationType::Snake => run_segment_snake(disp, cancel, self.duration, start),
+                    AnimationType::Curtain => run_segment_curtain(disp, cancel, self.duration, start),
+                    AnimationType::SineWave => run_segment_sine_wave(disp, cancel, self.duration, start),
+                    AnimationType::Random => unreachable!("random resolved above"),
                 }
             }
         }
     }
+}
+
+fn pick_random_type(rng: &mut SimpleRng) -> AnimationType {
+    let options = [
+        AnimationType::Static,
+        AnimationType::Pong,
+        AnimationType::MatrixRain,
+        AnimationType::Snake,
+        AnimationType::Curtain,
+        AnimationType::SineWave,
+    ];
+    options[rng.next_range(options.len() as u32) as usize].clone()
 }
 
 struct SimpleRng {
@@ -330,6 +363,322 @@ fn run_segment_pong(
             dir = -dir;
         }
 
+        sleep_or_cancel(cancel, frame_interval)?;
+    }
+}
+
+fn run_snake(
+    disp: &mut dyn PixelDisplay,
+    cancel: &CancelToken,
+    rng: &mut SimpleRng,
+    duration: Duration,
+    start: std::time::Instant,
+) -> Result<()> {
+    let frame_interval = Duration::from_millis(120);
+    let target_len: usize = 10;
+
+    let mut body: VecDeque<(i8, i8)> = VecDeque::new();
+    body.push_front((16, 4));
+    body.push_front((17, 4));
+    body.push_front((18, 4));
+
+    let mut food = spawn_snake_food(&body, rng);
+    let mut last_dir: (i8, i8) = (1, 0);
+
+    loop {
+        if check_timeout(cancel, duration, start)? {
+            return Ok(());
+        }
+
+        let head = *body.front().unwrap();
+        let dir = pick_snake_dir(head, food, last_dir, &body);
+        last_dir = dir;
+
+        let new_head = (head.0 + dir.0, head.1 + dir.1);
+        body.push_front(new_head);
+
+        let ate = new_head == food;
+        if ate {
+            food = spawn_snake_food(&body, rng);
+        }
+        if !ate || body.len() > target_len {
+            body.pop_back();
+        }
+
+        let mut frame: Frame = [0u8; 32];
+        for &(x, y) in body.iter() {
+            if x >= 0 && x < DISPLAY_WIDTH as i8 && y >= 0 && y < DISPLAY_HEIGHT as i8 {
+                framebuf::set_pixel(&mut frame, x as usize, y as usize, true);
+            }
+        }
+        framebuf::set_pixel(&mut frame, food.0 as usize, food.1 as usize, true);
+        disp.write_framebuffer(&frame);
+
+        sleep_or_cancel(cancel, frame_interval)?;
+    }
+}
+
+fn pick_snake_dir(
+    head: (i8, i8),
+    food: (i8, i8),
+    last: (i8, i8),
+    body: &VecDeque<(i8, i8)>,
+) -> (i8, i8) {
+    let dx = food.0 - head.0;
+    let dy = food.1 - head.1;
+
+    let mut candidates: Vec<(i8, i8)> = Vec::with_capacity(4);
+    if dx.abs() >= dy.abs() {
+        if dx != 0 { candidates.push((dx.signum(), 0)); }
+        if dy != 0 { candidates.push((0, dy.signum())); }
+    } else {
+        if dy != 0 { candidates.push((0, dy.signum())); }
+        if dx != 0 { candidates.push((dx.signum(), 0)); }
+    }
+    for d in &[(1i8, 0i8), (-1, 0), (0, 1), (0, -1)] {
+        if !candidates.contains(d) { candidates.push(*d); }
+    }
+    let reverse = (-last.0, -last.1);
+    candidates.retain(|d| *d != reverse);
+
+    let body_len = body.len();
+    for d in &candidates {
+        let next = (head.0 + d.0, head.1 + d.1);
+        if next.0 < 0 || next.0 >= DISPLAY_WIDTH as i8 { continue; }
+        if next.1 < 0 || next.1 >= DISPLAY_HEIGHT as i8 { continue; }
+        if body.iter().take(body_len.saturating_sub(1)).any(|&p| p == next) { continue; }
+        return *d;
+    }
+    last
+}
+
+fn spawn_snake_food(body: &VecDeque<(i8, i8)>, rng: &mut SimpleRng) -> (i8, i8) {
+    for _ in 0..40 {
+        let x = rng.next_range(DISPLAY_WIDTH as u32) as i8;
+        let y = rng.next_range(DISPLAY_HEIGHT as u32) as i8;
+        if !body.iter().any(|&p| p == (x, y)) {
+            return (x, y);
+        }
+    }
+    (0, 0)
+}
+
+fn run_curtain(
+    disp: &mut dyn PixelDisplay,
+    cancel: &CancelToken,
+    duration: Duration,
+    start: std::time::Instant,
+) -> Result<()> {
+    let frame_interval = Duration::from_millis(60);
+    let total = DISPLAY_WIDTH * 2;
+    let mut phase: usize = 0;
+
+    loop {
+        if check_timeout(cancel, duration, start)? {
+            return Ok(());
+        }
+
+        let mut frame: Frame = [0u8; 32];
+        if phase < DISPLAY_WIDTH {
+            for c in 0..=phase {
+                frame[c] = 0xFF;
+            }
+        } else {
+            let start_col = phase - DISPLAY_WIDTH + 1;
+            for c in start_col..DISPLAY_WIDTH {
+                frame[c] = 0xFF;
+            }
+        }
+        disp.write_framebuffer(&frame);
+
+        phase = (phase + 1) % total;
+        sleep_or_cancel(cancel, frame_interval)?;
+    }
+}
+
+fn run_sine_wave(
+    disp: &mut dyn PixelDisplay,
+    cancel: &CancelToken,
+    duration: Duration,
+    start: std::time::Instant,
+) -> Result<()> {
+    use core::f32::consts::PI;
+    let frame_interval = Duration::from_millis(60);
+    let wavelength: f32 = 14.0;
+    let amplitude: f32 = 3.0;
+    let mid: f32 = 3.5;
+    let mut phase: f32 = 0.0;
+
+    loop {
+        if check_timeout(cancel, duration, start)? {
+            return Ok(());
+        }
+
+        let mut frame: Frame = [0u8; 32];
+        for x in 0..DISPLAY_WIDTH {
+            let y = mid + amplitude * ((x as f32 + phase) * 2.0 * PI / wavelength).sin();
+            let yy = y.round() as i32;
+            if yy >= 0 && yy < DISPLAY_HEIGHT as i32 {
+                framebuf::set_pixel(&mut frame, x, yy as usize, true);
+            }
+        }
+        disp.write_framebuffer(&frame);
+
+        phase += 0.5;
+        sleep_or_cancel(cancel, frame_interval)?;
+    }
+}
+
+fn run_segment_snake(
+    disp: &mut dyn SegmentDisplay,
+    cancel: &CancelToken,
+    duration: Duration,
+    start: std::time::Instant,
+) -> Result<()> {
+    // Snake walks the outer perimeter of each digit, bouncing off the ends.
+    // Every digit is entered at 'a' and closes its loop back to 'a' before
+    // moving on; segment 'g' (middle) is skipped.
+    //   moving right: a, b, c, d, e, f, a  (clockwise, 7 steps)
+    //   moving left:  a, f, e, d, c, b, a  (counter-clockwise, 7 steps)
+    // The endpoint digit at each bounce drops the closing 'a' (6 steps only).
+    const SEG_FWD: [u16; 7] = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x01];
+    const SEG_REV: [u16; 7] = [0x01, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01];
+
+    let frame_interval = Duration::from_millis(120);
+    let n = disp.display_length();
+    if n == 0 {
+        return Ok(());
+    }
+    let trail: usize = 3;
+
+    let mut digit: i32 = 0;
+    let mut step: usize = 0;
+    let mut dir: i32 = 1;
+    let mut history: VecDeque<(usize, u16)> = VecDeque::with_capacity(trail);
+
+    loop {
+        if check_timeout(cancel, duration, start)? {
+            return Ok(());
+        }
+
+        let seg = if dir > 0 { SEG_FWD[step] } else { SEG_REV[step] };
+        history.push_front((digit as usize, seg));
+        while history.len() > trail {
+            history.pop_back();
+        }
+
+        let mut segs = vec![0u16; n];
+        for &(d, s) in history.iter() {
+            segs[d] |= s;
+        }
+        disp.write_segments(&segs, false);
+
+        step += 1;
+        let next_digit = digit + dir;
+        let at_endpoint = next_digit < 0 || next_digit >= n as i32;
+        let max_step = if at_endpoint { 6 } else { 7 };
+        if step >= max_step {
+            step = 0;
+            if at_endpoint {
+                dir = -dir;
+                digit += dir;
+                digit = digit.clamp(0, (n as i32 - 1).max(0));
+            } else {
+                digit = next_digit;
+            }
+        }
+
+        sleep_or_cancel(cancel, frame_interval)?;
+    }
+}
+
+fn run_segment_curtain(
+    disp: &mut dyn SegmentDisplay,
+    cancel: &CancelToken,
+    duration: Duration,
+    start: std::time::Instant,
+) -> Result<()> {
+    // Fill digits left-to-right, 3 stages each:
+    //   e,f  →  a,d,e,f,g  →  a,b,c,d,e,f,g
+    // Completed digits stay at 0x7F. Once all digits are full, unfill
+    // left-to-right, peeling segments away in the same order they were
+    // laid down (remove e,f, then a,d,g, then b,c) while digits to the
+    // right remain fully lit:
+    //   a,b,c,d,e,f,g → a,b,c,d,g → b,c → (off)
+    const FILL: [u16; 3] = [0x30, 0x79, 0x7F];
+    const UNFILL: [u16; 3] = [0x4F, 0x06, 0x00];
+    let frame_interval = Duration::from_millis(150);
+    let n = disp.display_length();
+    if n == 0 {
+        return Ok(());
+    }
+    let fill_phases = n * 3;
+    let total = fill_phases * 2;
+    let mut phase: usize = 0;
+
+    loop {
+        if check_timeout(cancel, duration, start)? {
+            return Ok(());
+        }
+
+        let mut segs = vec![0u16; n];
+        if phase < fill_phases {
+            let current = phase / 3;
+            let stage = phase % 3;
+            for d in 0..current {
+                segs[d] = 0x7F;
+            }
+            segs[current] = FILL[stage];
+        } else {
+            let up = phase - fill_phases;
+            let current = up / 3;
+            let stage = up % 3;
+            segs[current] = UNFILL[stage];
+            for d in (current + 1)..n {
+                segs[d] = 0x7F;
+            }
+        }
+        disp.write_segments(&segs, false);
+
+        phase = (phase + 1) % total;
+        sleep_or_cancel(cancel, frame_interval)?;
+    }
+}
+
+fn run_segment_sine_wave(
+    disp: &mut dyn SegmentDisplay,
+    cancel: &CancelToken,
+    duration: Duration,
+    start: std::time::Instant,
+) -> Result<()> {
+    // Scroll one segment across every digit per step (a, then b, then c, ...),
+    // then unroll in the same order. 7 fill + 7 unfill steps per cycle.
+    const SEG_ORDER: [u16; 7] = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40];
+    let frame_interval = Duration::from_millis(150);
+    let n = disp.display_length();
+    let total = SEG_ORDER.len() * 2;
+    let mut phase: usize = 0;
+
+    loop {
+        if check_timeout(cancel, duration, start)? {
+            return Ok(());
+        }
+
+        let mut mask: u16 = 0;
+        if phase < SEG_ORDER.len() {
+            for i in 0..=phase {
+                mask |= SEG_ORDER[i];
+            }
+        } else {
+            let start_i = phase - SEG_ORDER.len() + 1;
+            for i in start_i..SEG_ORDER.len() {
+                mask |= SEG_ORDER[i];
+            }
+        }
+        let segs = vec![mask; n];
+        disp.write_segments(&segs, false);
+
+        phase = (phase + 1) % total;
         sleep_or_cancel(cancel, frame_interval)?;
     }
 }


### PR DESCRIPTION
## Summary
- Adds `snake`, `curtain`, `sine_wave` (aliases `sine`/`sinewave`), and `random` animations, each with both pixel-matrix and 7-segment renderings
- Rewrites segment `snake` (3-segment trail around each digit's perimeter) and segment `curtain` (per-digit fill/unfill stages) to match their pixel counterparts — prior segment implementations were incorrect
- Thins the pixel `sine_wave` line from 2 pixels to 1 pixel for cleaner rendering
- Updates CLAUDE.md to document the new animation values

Closes #1

## Test plan
- [ ] Flash MAX7219 build and trigger each new animation from the server (`snake`, `curtain`, `sine_wave`, `random`)
- [ ] Flash TM1637 build and verify segment `snake` walks the perimeter correctly and `curtain` fills/unfills in the documented stages
- [ ] Confirm `random` picks from the six non-random variants at widget start
- [ ] Verify existing `static`, `pong`, `matrix_rain` animations still work on both display types