### PR TITLE
Remote config updates via server poll response

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Mirrors `led-kurokku-go`:
 
 - **`config`** — `AppConfig` loaded exclusively from NVS; placeholder defaults for missing keys. `open_nvs()` opens the `kurokku` NVS namespace. Provisioned via `tools/provision.py`.
 - **`display/`** — Trait definitions + drivers. `max7219.rs` (SPI), `tm1637.rs` (bit-banged 2-wire; 5µs bit delay via `Ets::delay_us`).
-- **`engine`** — Two-thread display loop. Network thread feeds `SharedState`, display thread runs widgets. Cancel token shared between threads: network thread cancels current widget on instruction change, display thread installs fresh token when starting each widget. Network loop deduplicates repeated identical polls via `last_served` tracking. Falls back to clock on error/widget completion.
+- **`engine`** — Two-thread display loop. Network thread feeds `SharedState`, display thread runs widgets. Cancel token shared between threads: network thread cancels current widget on instruction change, display thread installs fresh token when starting each widget. Network loop deduplicates repeated identical polls via `last_served` tracking. Falls back to clock on error/widget completion. A remote `config` field (deduped via `last_config`) is applied by the display thread through `apply_config_update` — it persists changed keys to NVS and applies syslog/timezone live, without swapping the active widget.
 - **`font`** — 5x7 ASCII bitmap font (columns, bit 0 = top row). `render_text()` joins glyphs with 1-column gaps.
 - **`font_7seg`** — character → 7-segment bitmask table (u8). `encode(char)`, `digit(u8)`, `encode_text(&str)`. Table ported from Go `segfont.Seg7` / Python `SEGMENTS`. `encode_text` folds `.` into the previous digit's DP bit (0x80).
 - **`framebuf`** — `Frame = [u8; 32]`, column-major. `blit_text`, `blit_text_centered`, `set_pixel`.
@@ -129,7 +129,7 @@ Mirrors `led-kurokku-go`:
   - `animation` — pixel: `static` (TV noise), `pong` (bouncing ball), `matrix_rain` (falling columns). Segment: `static` (random segments), `pong` (vertical-bar "ball" bouncing L/R across each digit in turn: left verts → right verts → next digit), `matrix_rain` (per-side raindrops per digit, top-vert → bottom-vert → bottom-horizontal, multiple concurrent drops).
   - `raw_render` — dumb renderer: server sends pixel/segment data directly.
   - `status` — shows IP address, errors, startup messages. Pixel scrolls if > 32px; segment scrolls if > display length (250ms cadence).
-- **`udp_log`** — Optional UDP syslog (RFC5424). Composite logger wraps `EspLogger` (serial) + UDP sink. `init()` replaces `EspLogger::initialize_default()`. `enable_udp(host, device_id)` called after WiFi connects if `syslog_host` is configured. Fire-and-forget, non-blocking.
+- **`udp_log`** — Optional UDP syslog (RFC5424). Composite logger wraps `EspLogger` (serial) + UDP sink. `init()` replaces `EspLogger::initialize_default()`. `enable_udp(host, device_id)` called after WiFi connects if `syslog_host` is configured. The target lives in a `RwLock<Option<…>>` so it can be retargeted at runtime via a remote `config` update; `disable_udp()` clears it. Fire-and-forget, non-blocking.
 - **`wifi`** — `connect()` blocks until WiFi + IP. `sync_ntp()` returns SNTP handle for periodic re-sync.
 
 ### Server API Contract
@@ -146,11 +146,19 @@ Response envelope:
 {
   "instruction": { ... },
   "brightness": 8,
-  "poll_interval_ms": 5000
+  "poll_interval_ms": 5000,
+  "config": { "syslog_host": "192.168.1.50:5514", "tz": "CST6CDT,M3.2.0,M11.1.0" }
 }
 ```
 
 All top-level fields are optional. `brightness` (0-15) overrides display brightness. `poll_interval_ms` adjusts the polling interval for subsequent requests.
+
+`config` remotely updates persisted NVS settings without re-provisioning over serial — a side channel applied alongside whatever `instruction` is showing (it does **not** swap the active widget). Supported keys:
+
+- `syslog_host` — UDP syslog target as `host:port`. Empty string `""` disables syslog. Applied live via `udp_log::enable_udp`/`disable_udp`.
+- `tz` — POSIX TZ string. Applied live via `setenv`/`tzset`.
+
+Omitted keys are left unchanged. Both keys are persisted to NVS so they survive reboot. The device deduplicates against the last-applied `config`, so the server can keep returning the same block on every poll without churning NVS flash (a write only happens when the value actually changes, and ESP-IDF NVS itself skips identical writes). This is the only way to change logging/timezone on a deployed device short of serial re-provisioning, since OTA replaces only the firmware image and preserves the NVS partition.
 
 #### Instruction Types
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,6 +99,26 @@ pub fn open_nvs(
         .map_err(|e| anyhow::anyhow!("NVS open failed: {}", e))
 }
 
+/// Persist a single string key to NVS, or remove it when `value` is None.
+///
+/// Used by remote config updates (the `config` field in a server response) so
+/// settings like the syslog target can change without re-provisioning a device
+/// over serial. ESP-IDF NVS skips the flash write when the stored value already
+/// matches, so re-applying the same value is cheap.
+pub fn persist_str_opt(
+    nvs: &mut EspNvs<NvsDefault>,
+    key: &str,
+    value: Option<&str>,
+) -> Result<()> {
+    match value {
+        Some(v) => nvs_set_str(nvs, key, v),
+        None => {
+            let _ = nvs.remove(key);
+            Ok(())
+        }
+    }
+}
+
 // --- NVS helpers ---
 
 fn nvs_get_str(nvs: &EspNvs<NvsDefault>, key: &str) -> Option<String> {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,12 +1,13 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use esp_idf_svc::nvs::EspDefaultNvsPartition;
 use esp_idf_svc::wifi::{BlockingWifi, EspWifi};
 use log;
 
 use crate::config::AppConfig;
 use crate::display::AnyDisplay;
-use crate::network::{InstructionSource, WidgetInstruction};
+use crate::network::{ConfigUpdate, InstructionSource, WidgetInstruction};
 use crate::widget::clock::Clock;
 use crate::widget::status::Status;
 use crate::widget::{CancelToken, Widget};
@@ -21,6 +22,10 @@ struct SharedState {
     pending_brightness: Option<u8>,
     /// Set to true when the network thread detects an OTA request.
     ota_url: Option<String>,
+    /// Remote config update from the server (syslog target, timezone, …).
+    /// Applied by the display thread as a side effect without disturbing the
+    /// active widget. Deduplicated by the network thread.
+    pending_config: Option<ConfigUpdate>,
     /// Cancel token for the currently running widget. The network thread
     /// signals this when it installs a new instruction so the widget wakes
     /// up and the display loop can pick the instruction up. The display
@@ -31,11 +36,13 @@ struct SharedState {
 /// Engine manages the two-thread display loop.
 pub struct Engine {
     config: AppConfig,
+    /// NVS partition handle so remote config updates can be persisted.
+    nvs_partition: EspDefaultNvsPartition,
 }
 
 impl Engine {
-    pub fn new(config: AppConfig) -> Self {
-        Self { config }
+    pub fn new(config: AppConfig, nvs_partition: EspDefaultNvsPartition) -> Self {
+        Self { config, nvs_partition }
     }
 
     /// Run the engine. This blocks forever.
@@ -56,6 +63,7 @@ impl Engine {
             pending_instruction: None,
             pending_brightness: None,
             ota_url: None,
+            pending_config: None,
             current_cancel: CancelToken::new(),
         }));
 
@@ -92,6 +100,15 @@ impl Engine {
                         AnyDisplay::Pixel(ref mut d) => d.set_brightness(brightness),
                         AnyDisplay::Segment(ref mut d) => d.set_brightness(brightness),
                     }
+                }
+
+                if let Some(update) = state.pending_config.take() {
+                    // Apply persisted-config changes without disturbing the
+                    // active widget. Release the lock first — NVS writes and
+                    // logging can be slow.
+                    drop(state);
+                    self.apply_config_update(&update);
+                    continue;
                 }
 
                 if let Some(url) = state.ota_url.take() {
@@ -200,6 +217,46 @@ impl Engine {
             }
         }
     }
+
+    /// Apply a remote config update: persist the changed keys to NVS and apply
+    /// them live where possible (syslog target, timezone) so no reboot is
+    /// needed. Called from the display thread.
+    fn apply_config_update(&self, update: &ConfigUpdate) {
+        let mut nvs = match crate::config::open_nvs(self.nvs_partition.clone()) {
+            Ok(n) => n,
+            Err(e) => {
+                log::error!("Config update: NVS open failed: {}", e);
+                return;
+            }
+        };
+
+        if let Some(host) = update.syslog_host.as_deref() {
+            if host.is_empty() {
+                if let Err(e) = crate::config::persist_str_opt(&mut nvs, "syslog_host", None) {
+                    log::error!("Config update: persist syslog_host failed: {}", e);
+                }
+                crate::udp_log::disable_udp();
+            } else {
+                if let Err(e) =
+                    crate::config::persist_str_opt(&mut nvs, "syslog_host", Some(host))
+                {
+                    log::error!("Config update: persist syslog_host failed: {}", e);
+                }
+                crate::udp_log::enable_udp(host, &self.config.device_id);
+            }
+        }
+
+        if let Some(tz) = update.tz.as_deref() {
+            if !tz.is_empty() {
+                if let Err(e) = crate::config::persist_str_opt(&mut nvs, "tz", Some(tz)) {
+                    log::error!("Config update: persist tz failed: {}", e);
+                }
+                if let Err(e) = crate::wifi::set_timezone(tz) {
+                    log::warn!("Config update: apply tz failed: {}", e);
+                }
+            }
+        }
+    }
 }
 
 const MAX_CONSECUTIVE_FAILURES: u32 = 60;
@@ -214,6 +271,7 @@ fn network_loop(
     // restart the active widget every interval. The server is expected to
     // return the *current* desired state on each poll, not a diff.
     let mut last_served: Option<WidgetInstruction> = None;
+    let mut last_config: Option<ConfigUpdate> = None;
     let mut consecutive_failures: u32 = 0;
 
     loop {
@@ -236,6 +294,16 @@ fn network_loop(
 
                 if let Some(brightness) = resp.brightness {
                     state.pending_brightness = Some(brightness);
+                }
+
+                if let Some(config) = resp.config {
+                    // Dedup so we don't rewrite NVS every poll — the server is
+                    // expected to keep returning the current desired config.
+                    if last_config.as_ref() != Some(&config) {
+                        log::info!("Config update received: {:?}", config);
+                        state.pending_config = Some(config.clone());
+                        last_config = Some(config);
+                    }
                 }
             }
             Ok(None) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,10 @@ fn run(
 ) -> ! {
     use widget::{CancelToken, Widget};
 
+    // Keep a partition handle for the engine so remote config updates can be
+    // persisted. wifi::connect consumes the original below.
+    let engine_nvs = nvs_partition.clone();
+
     // Show startup banner. Widgets that don't yet support the active display
     // type silently return Err — that's fine here; we ignore it.
     {
@@ -194,7 +198,7 @@ fn run(
         ),
     );
 
-    let eng = engine::Engine::new(cfg);
+    let eng = engine::Engine::new(cfg, engine_nvs);
     log::info!("Starting engine");
     eng.run(any_disp, source, wifi_handle);
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -52,12 +52,30 @@ fn default_scroll_speed() -> u64 { 50 }
 fn default_repeats() -> i32 { 1 }
 fn default_animation_duration() -> u64 { 30 }
 
+/// Remote configuration update delivered alongside an instruction.
+///
+/// Lets the server change persisted NVS settings without re-provisioning a
+/// device over serial. Fields omitted from the JSON are left unchanged; an
+/// empty `syslog_host` string disables syslog. Updates are deduplicated by
+/// the device, so the server can keep returning the same `config` on every
+/// poll without churning NVS flash.
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct ConfigUpdate {
+    /// UDP syslog target as "host:port". Empty string disables syslog.
+    #[serde(default)]
+    pub syslog_host: Option<String>,
+    /// POSIX TZ string, e.g. "CST6CDT,M3.2.0,M11.1.0".
+    #[serde(default)]
+    pub tz: Option<String>,
+}
+
 /// Full server response.
 #[derive(Deserialize, Debug, Clone)]
 pub struct ServerResponse {
     pub instruction: Option<WidgetInstruction>,
     pub brightness: Option<u8>,
     pub poll_interval_ms: Option<u64>,
+    pub config: Option<ConfigUpdate>,
 }
 
 /// Trait for fetching instructions from a server.

--- a/src/udp_log.rs
+++ b/src/udp_log.rs
@@ -1,5 +1,5 @@
 use std::net::UdpSocket;
-use std::sync::OnceLock;
+use std::sync::RwLock;
 
 use esp_idf_svc::log::EspLogger;
 
@@ -9,7 +9,7 @@ struct UdpTarget {
     hostname: String,
 }
 
-static UDP_TARGET: OnceLock<UdpTarget> = OnceLock::new();
+static UDP_TARGET: RwLock<Option<UdpTarget>> = RwLock::new(None);
 
 static LOGGER: CompositeLogger = CompositeLogger {
     esp: EspLogger::new(),
@@ -27,18 +27,20 @@ impl log::Log for CompositeLogger {
     fn log(&self, record: &log::Record) {
         self.esp.log(record);
 
-        if let Some(udp) = UDP_TARGET.get() {
-            let pri = syslog_priority(record.level());
-            let module = record.module_path().unwrap_or("-");
-            // RFC5424: <PRI>VERSION TIMESTAMP HOSTNAME APP-NAME PROCID MSGID SD MSG
-            let msg = format!(
-                "<{}>1 - {} {} - - - {}",
-                pri,
-                udp.hostname,
-                module,
-                record.args(),
-            );
-            let _ = udp.socket.send_to(msg.as_bytes(), &udp.target);
+        if let Ok(guard) = UDP_TARGET.read() {
+            if let Some(udp) = guard.as_ref() {
+                let pri = syslog_priority(record.level());
+                let module = record.module_path().unwrap_or("-");
+                // RFC5424: <PRI>VERSION TIMESTAMP HOSTNAME APP-NAME PROCID MSGID SD MSG
+                let msg = format!(
+                    "<{}>1 - {} {} - - - {}",
+                    pri,
+                    udp.hostname,
+                    module,
+                    record.args(),
+                );
+                let _ = udp.socket.send_to(msg.as_bytes(), &udp.target);
+            }
         }
     }
 
@@ -77,10 +79,29 @@ pub fn enable_udp(host: &str, device_id: &str) {
         log::warn!("UDP socket set_nonblocking failed: {}", e);
     }
 
-    let _ = UDP_TARGET.set(UdpTarget {
+    let new_target = UdpTarget {
         socket,
         target: host.to_string(),
         hostname: device_id.to_string(),
-    });
+    };
+    // Replace any existing target so the syslog destination can be changed at
+    // runtime via a remote `config` update. Drop the write guard before
+    // logging — `log()` takes a read lock and would otherwise deadlock.
+    match UDP_TARGET.write() {
+        Ok(mut guard) => *guard = Some(new_target),
+        Err(_) => {
+            log::warn!("UDP target lock poisoned; syslog not updated");
+            return;
+        }
+    }
     log::info!("UDP syslog enabled → {}", host);
+}
+
+/// Disable UDP syslog, dropping the current target. Subsequent logs go to
+/// serial only until `enable_udp` is called again.
+pub fn disable_udp() {
+    if let Ok(mut guard) = UDP_TARGET.write() {
+        *guard = None;
+    }
+    log::info!("UDP syslog disabled");
 }


### PR DESCRIPTION
## What

Lets the server change a deployed device's persisted NVS settings (`syslog_host`, `tz`) **remotely**, without serial re-provisioning or a reboot. Previously the only way to change the logging target was a physical serial re-flash of NVS — OTA replaces only the firmware image and preserves the NVS partition.

## How

- New optional `config` block in the poll response (sibling to `brightness`/`poll_interval_ms`, not a widget instruction), so it composes with whatever instruction is showing rather than swapping the active widget.
- The network thread deduplicates against the last-applied config (so NVS isn't rewritten every poll); the display thread applies it via `apply_config_update` — persists changed keys to NVS and applies them live (UDP syslog retarget, `tzset`).
- `UDP_TARGET` becomes a re-settable `RwLock<Option<UdpTarget>>` (was a write-once `OnceLock`), so the syslog destination can actually change at runtime. Added `disable_udp()`.
- Engine now holds an `EspDefaultNvsPartition` handle to persist updates.

## Contract

Omitted keys are left unchanged; empty `syslog_host` (`""`) disables syslog. Documented in `CLAUDE.md`.

## Testing

- `cargo build` clean (no new warnings).
- Flashed on hardware: boots cleanly through `Starting engine` (verifies the NVS-handle/partition-clone wiring).
- Server-side emit lands in companion PR swilcox/kurokku-esp-server#remote-device-config.