### PR TITLE
Add observability: log level control, RSSI + CPU temp telemetry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ All config is loaded from the `kurokku` NVS namespace on boot. Unset keys fall b
 | `format_24h` | u8 (0/1) | `1` | 24-hour clock format |
 | `brightness` | u8 | `4` | Default display brightness 0-15 |
 | `poll_ms` | i32 | `5000` | Server poll interval in ms |
+| `log_level` | string | `info` | Max log level: `off`/`error`/`warn`/`info`/`debug`/`trace` |
 
 ### Provisioning a Device
 
@@ -117,12 +118,13 @@ Mirrors `led-kurokku-go`:
 
 - **`config`** — `AppConfig` loaded exclusively from NVS; placeholder defaults for missing keys. `open_nvs()` opens the `kurokku` NVS namespace. Provisioned via `tools/provision.py`.
 - **`display/`** — Trait definitions + drivers. `max7219.rs` (SPI), `tm1637.rs` (bit-banged 2-wire; 5µs bit delay via `Ets::delay_us`).
-- **`engine`** — Two-thread display loop. Network thread feeds `SharedState`, display thread runs widgets. Cancel token shared between threads: network thread cancels current widget on instruction change, display thread installs fresh token when starting each widget. Network loop deduplicates repeated identical polls via `last_served` tracking. Falls back to clock on error/widget completion. A remote `config` field (deduped via `last_config`) is applied by the display thread through `apply_config_update` — it persists changed keys to NVS and applies syslog/timezone live, without swapping the active widget.
+- **`engine`** — Two-thread display loop. Network thread feeds `SharedState`, display thread runs widgets. Cancel token shared between threads: network thread cancels current widget on instruction change, display thread installs fresh token when starting each widget. Network loop deduplicates repeated identical polls via `last_served` tracking. Falls back to clock on error/widget completion. A remote `config` field (deduped via `last_config`) is applied by the display thread through `apply_config_update` — it persists changed keys to NVS and applies syslog/timezone/log-level live, without swapping the active widget. The network thread also emits a periodic `telemetry:` log line (WiFi RSSI + CPU die temperature, every 60s) via `log_telemetry` — health signal that flows to syslog when enabled.
 - **`font`** — 5x7 ASCII bitmap font (columns, bit 0 = top row). `render_text()` joins glyphs with 1-column gaps.
 - **`font_7seg`** — character → 7-segment bitmask table (u8). `encode(char)`, `digit(u8)`, `encode_text(&str)`. Table ported from Go `segfont.Seg7` / Python `SEGMENTS`. `encode_text` folds `.` into the previous digit's DP bit (0x80).
 - **`framebuf`** — `Frame = [u8; 32]`, column-major. `blit_text`, `blit_text_centered`, `set_pixel`.
 - **`network/`** — `InstructionSource` trait (polling now, WebSocket later). `polling.rs` implements HTTP GET polling. `WidgetInstruction` enum for server commands.
 - **`ota`** — `perform_ota(url)` downloads firmware, flashes inactive OTA partition, reboots. Uses ESP-IDF's built-in two-OTA partition table.
+- **`temp_sensor`** — Thin wrapper over ESP-IDF's `temperature_sensor` driver (raw `sys` bindings; not wrapped by `esp-idf-svc`). `TempSensor::new()` installs/enables the on-die sensor; `read_celsius()` reads it. Used for telemetry.
 - **`widget/`** — `Widget` trait (`name`, `run`). `CancelToken` for cooperative cancellation. `sleep_or_cancel` polls at 50ms granularity. Each widget dispatches on `AnyDisplay` to render on pixel or segment backends.
   - `clock` — 24h/12h with AM/PM double-blink pattern. Segment variant renders digits via `font_7seg::digit` with leading blank in 12h mode.
   - `message` — pixel: static centered if ≤32px wide, scrolling otherwise. Segment: static if fits in display length, otherwise window scroll (pad `width` blanks each side, slide 1 char per tick).
@@ -157,8 +159,9 @@ All top-level fields are optional. `brightness` (0-15) overrides display brightn
 
 - `syslog_host` — UDP syslog target as `host:port`. Empty string `""` disables syslog. Applied live via `udp_log::enable_udp`/`disable_udp`.
 - `tz` — POSIX TZ string. Applied live via `setenv`/`tzset`.
+- `log_level` — max log level (`off`/`error`/`warn`/`info`/`debug`/`trace`). Empty string is ignored; unrecognized values fall back to `info`. Applied live via `log::set_max_level`.
 
-Omitted keys are left unchanged. Both keys are persisted to NVS so they survive reboot. The device deduplicates against the last-applied `config`, so the server can keep returning the same block on every poll without churning NVS flash (a write only happens when the value actually changes, and ESP-IDF NVS itself skips identical writes). This is the only way to change logging/timezone on a deployed device short of serial re-provisioning, since OTA replaces only the firmware image and preserves the NVS partition.
+Omitted keys are left unchanged. All keys are persisted to NVS so they survive reboot. The device deduplicates against the last-applied `config`, so the server can keep returning the same block on every poll without churning NVS flash (a write only happens when the value actually changes, and ESP-IDF NVS itself skips identical writes). This is the only way to change logging/timezone/log-level on a deployed device short of serial re-provisioning, since OTA replaces only the firmware image and preserves the NVS partition.
 
 #### Instruction Types
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "led-kurokku-esp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "embuild",

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1,0 +1,17 @@
+# Ideas
+
+## Features
+
+### observability / logging
+* report wifi signal strength on some interval
+* report cpu temperature if there is one
+* ability to set and change logging level
+* probably need to make the logs less chatty: which message really matter?
+
+### widgets
+* can we support a .webp image display? animated?
+  * this would be the first step towards RGB displays
+  * initially only support monocrome .webp images or convert to mono on the fly... transparent and black are not lit and everything else is lit.
+  * how much harder is animated .webp?
+  * possibly remove the raw pixel widget type for matrix displays and use this instead
+  * would not work on tm1637

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,21 @@ pub struct AppConfig {
     pub tz: String,
     /// UDP syslog target as "host:port", e.g. "192.168.1.50:5514". None = disabled.
     pub syslog_host: Option<String>,
+    /// Maximum log level: "off", "error", "warn", "info", "debug", or "trace".
+    pub log_level: String,
+}
+
+/// Parse a log level string into a `LevelFilter`. Unrecognized values (including
+/// the empty string) fall back to `Info`.
+pub fn parse_level(s: &str) -> log::LevelFilter {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "off" => log::LevelFilter::Off,
+        "error" => log::LevelFilter::Error,
+        "warn" => log::LevelFilter::Warn,
+        "debug" => log::LevelFilter::Debug,
+        "trace" => log::LevelFilter::Trace,
+        _ => log::LevelFilter::Info,
+    }
 }
 
 impl AppConfig {
@@ -38,6 +53,7 @@ impl AppConfig {
         let poll_interval_ms = nvs_get_u32(nvs, "poll_ms").map(|v| v as u64).unwrap_or(5000);
         let tz = nvs_get_str(nvs, "tz").unwrap_or_else(|| "UTC0".to_string());
         let syslog_host = nvs_get_str(nvs, "syslog_host");
+        let log_level = nvs_get_str(nvs, "log_level").unwrap_or_else(|| "info".to_string());
 
         let cfg = Self {
             wifi_ssid,
@@ -49,10 +65,11 @@ impl AppConfig {
             poll_interval_ms,
             tz,
             syslog_host,
+            log_level,
         };
 
         log::info!(
-            "Config loaded: server={}, device={}, 24h={}, brightness={}, poll={}ms, tz={}, syslog={:?}",
+            "Config loaded: server={}, device={}, 24h={}, brightness={}, poll={}ms, tz={}, syslog={:?}, log_level={}",
             cfg.server_url,
             cfg.device_id,
             cfg.format_24h,
@@ -60,6 +77,7 @@ impl AppConfig {
             cfg.poll_interval_ms,
             cfg.tz,
             cfg.syslog_host,
+            cfg.log_level,
         );
 
         cfg
@@ -75,6 +93,7 @@ impl AppConfig {
         nvs_set_u8(nvs, "brightness", self.default_brightness)?;
         nvs_set_u32(nvs, "poll_ms", self.poll_interval_ms as u32)?;
         nvs_set_str(nvs, "tz", &self.tz)?;
+        nvs_set_str(nvs, "log_level", &self.log_level)?;
         match &self.syslog_host {
             Some(h) => nvs_set_str(nvs, "syslog_host", h)?,
             None => {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,5 +1,5 @@
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use esp_idf_svc::nvs::EspDefaultNvsPartition;
 use esp_idf_svc::wifi::{BlockingWifi, EspWifi};
@@ -139,7 +139,9 @@ impl Engine {
                 }
 
                 if let Some(instruction) = state.pending_instruction.take() {
-                    log::info!("New instruction: {:?}", instruction);
+                    // The network thread already logs the change at info level;
+                    // this is the display-side pickup, so keep it at debug.
+                    log::debug!("New instruction: {:?}", instruction);
 
                     current_widget = match instruction {
                         WidgetInstruction::Clock { format_24h } => {
@@ -195,8 +197,9 @@ impl Engine {
             // Run current widget for one iteration
             match current_widget.run(display, &cancel) {
                 Ok(()) => {
-                    // Widget finished (e.g. message done scrolling) — revert to clock
-                    log::info!("Widget finished, reverting to clock");
+                    // Widget finished (e.g. message done scrolling) — revert to
+                    // clock. Routine, so debug rather than info.
+                    log::debug!("Widget finished, reverting to clock");
                     current_widget = Box::new(Clock::new(current_format_24h));
                     let new_cancel = CancelToken::new();
                     shared.lock().unwrap().current_cancel = new_cancel.clone();
@@ -256,10 +259,26 @@ impl Engine {
                 }
             }
         }
+
+        if let Some(level) = update.log_level.as_deref() {
+            if !level.is_empty() {
+                if let Err(e) = crate::config::persist_str_opt(&mut nvs, "log_level", Some(level)) {
+                    log::error!("Config update: persist log_level failed: {}", e);
+                }
+                let filter = crate::config::parse_level(level);
+                log::set_max_level(filter);
+                log::info!("Log level set: {}", filter);
+            }
+        }
     }
 }
 
 const MAX_CONSECUTIVE_FAILURES: u32 = 60;
+
+/// How often the network thread logs device telemetry (RSSI, die temperature).
+/// Coarse on purpose — this is health signal, not a metrics feed, and it flows
+/// to syslog when enabled.
+const TELEMETRY_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Network thread loop. Polls the instruction source and updates shared state.
 fn network_loop(
@@ -273,6 +292,17 @@ fn network_loop(
     let mut last_served: Option<WidgetInstruction> = None;
     let mut last_config: Option<ConfigUpdate> = None;
     let mut consecutive_failures: u32 = 0;
+
+    // Internal temperature sensor for periodic health telemetry. If it fails to
+    // install we just skip temperature reporting rather than taking down polls.
+    let temp_sensor = match crate::temp_sensor::TempSensor::new() {
+        Ok(s) => Some(s),
+        Err(e) => {
+            log::warn!("Temperature sensor unavailable: {}", e);
+            None
+        }
+    };
+    let mut last_telemetry = Instant::now();
 
     loop {
         match source.next_instruction() {
@@ -339,7 +369,30 @@ fn network_loop(
             }
         }
 
+        // Periodic device health telemetry. Logged (not pushed to the server)
+        // so it lands in syslog when a target is configured.
+        if last_telemetry.elapsed() >= TELEMETRY_INTERVAL {
+            last_telemetry = Instant::now();
+            log_telemetry(&wifi, temp_sensor.as_ref());
+        }
+
         let interval = source.recommended_interval();
         std::thread::sleep(interval);
     }
+}
+
+/// Emit a single telemetry line with WiFi RSSI and CPU die temperature. Either
+/// field is omitted (shown as `?`) when unavailable.
+fn log_telemetry(wifi: &Option<SharedWifi>, temp_sensor: Option<&crate::temp_sensor::TempSensor>) {
+    let rssi = wifi
+        .as_ref()
+        .and_then(|w| w.lock().ok())
+        .and_then(|guard| crate::wifi::get_rssi(&guard));
+    let temp_c = temp_sensor.and_then(|s| s.read_celsius());
+
+    log::info!(
+        "telemetry: rssi={} temp_c={}",
+        rssi.map(|v| v.to_string()).unwrap_or_else(|| "?".into()),
+        temp_c.map(|v| format!("{:.1}", v)).unwrap_or_else(|| "?".into()),
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,8 @@ mod network;
 #[cfg(target_os = "espidf")]
 mod ota;
 #[cfg(target_os = "espidf")]
+mod temp_sensor;
+#[cfg(target_os = "espidf")]
 mod udp_log;
 #[cfg(target_os = "espidf")]
 mod widget;
@@ -53,6 +55,10 @@ fn main() {
     let nvs = config::open_nvs(nvs_partition.clone()).expect("Failed to open NVS");
     let cfg = config::AppConfig::load(&nvs);
     drop(nvs); // release the NVS handle before WiFi needs the partition
+
+    // Apply the configured log level now that NVS is loaded. Until this point
+    // we run at the logger's default level so startup/config logs are visible.
+    log::set_max_level(config::parse_level(&cfg.log_level));
 
     #[cfg(feature = "max7219")]
     {

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -67,6 +67,9 @@ pub struct ConfigUpdate {
     /// POSIX TZ string, e.g. "CST6CDT,M3.2.0,M11.1.0".
     #[serde(default)]
     pub tz: Option<String>,
+    /// Maximum log level: "off", "error", "warn", "info", "debug", or "trace".
+    #[serde(default)]
+    pub log_level: Option<String>,
 }
 
 /// Full server response.

--- a/src/temp_sensor.rs
+++ b/src/temp_sensor.rs
@@ -1,0 +1,50 @@
+//! Thin wrapper over the ESP-IDF internal temperature sensor.
+//!
+//! `esp-idf-svc` doesn't wrap the `temperature_sensor` driver, so we call the
+//! raw `sys` bindings directly. The ESP32-C3 (and C6) have an on-die sensor
+//! that reports a coarse junction temperature — useful for spotting a device
+//! cooking in an enclosure, not for precision measurement.
+
+use anyhow::Result;
+use esp_idf_svc::sys;
+
+/// An installed, enabled temperature sensor. Owns the driver handle; the raw
+/// pointer makes it `!Send`, so create and read it from a single thread.
+pub struct TempSensor {
+    handle: sys::temperature_sensor_handle_t,
+}
+
+impl TempSensor {
+    /// Install and enable the sensor. The measurement range is a hint that lets
+    /// the driver pick an offset; readings outside it just lose accuracy.
+    pub fn new() -> Result<Self> {
+        // Start from a zeroed config so we stay forward-compatible with extra
+        // fields (e.g. `flags`) added in later IDF versions, and only set the
+        // range. clk_src defaults to TEMPERATURE_SENSOR_CLK_SRC_DEFAULT (0).
+        let mut config = sys::temperature_sensor_config_t::default();
+        config.range_min = -10;
+        config.range_max = 80;
+
+        let mut handle: sys::temperature_sensor_handle_t = core::ptr::null_mut();
+        let err = unsafe { sys::temperature_sensor_install(&config, &mut handle) };
+        if err != sys::ESP_OK {
+            anyhow::bail!("temperature_sensor_install failed: {}", err);
+        }
+        let err = unsafe { sys::temperature_sensor_enable(handle) };
+        if err != sys::ESP_OK {
+            anyhow::bail!("temperature_sensor_enable failed: {}", err);
+        }
+        Ok(Self { handle })
+    }
+
+    /// Read the current die temperature in degrees Celsius, or None on error.
+    pub fn read_celsius(&self) -> Option<f32> {
+        let mut out: f32 = 0.0;
+        let err = unsafe { sys::temperature_sensor_get_celsius(self.handle, &mut out) };
+        if err == sys::ESP_OK {
+            Some(out)
+        } else {
+            None
+        }
+    }
+}

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -46,6 +46,20 @@ pub fn connect(
     Ok(wifi)
 }
 
+/// Read the current AP signal strength (RSSI) in dBm, or None if the station
+/// isn't associated. Backed by the global `esp_wifi_sta_get_rssi`, so it does
+/// not need the WiFi handle locked — the parameter just documents that a
+/// connection is expected.
+pub fn get_rssi(_wifi: &BlockingWifi<EspWifi<'static>>) -> Option<i32> {
+    let mut rssi: core::ffi::c_int = 0;
+    let err = unsafe { esp_idf_svc::sys::esp_wifi_sta_get_rssi(&mut rssi) };
+    if err == esp_idf_svc::sys::ESP_OK {
+        Some(rssi as i32)
+    } else {
+        None
+    }
+}
+
 /// Get the station IP address as a string, or None if not connected.
 pub fn get_ip(wifi: &BlockingWifi<EspWifi<'static>>) -> Option<String> {
     wifi.wifi()


### PR DESCRIPTION
Implements the observability/logging items from `IDEAS.md`.

## Changes

- **Remote/persisted log level** — new `log_level` NVS key + `parse_level()` helper, a `log_level` field on `ConfigUpdate`, applied at startup (`main.rs`) and live on remote config update (`engine.rs`) via `log::set_max_level`. Mirrors the existing `tz`/`syslog_host` flow: persisted, deduped, no reboot.
- **WiFi RSSI** — `wifi::get_rssi()` wrapping `esp_wifi_sta_get_rssi`.
- **CPU temperature** — new `temp_sensor` module wrapping ESP-IDF's `temperature_sensor` driver via raw `sys` bindings (not wrapped by `esp-idf-svc`). Installs once in the network thread; skips gracefully if install fails.
- **Telemetry** — RSSI + die temp emitted together as one `telemetry: rssi=… temp_c=…` line every 60s from the network loop. Logged only (no server contract change), so it flows to syslog when a target is configured.
- **Quieter logs** — demoted the routine display-thread "New instruction" pickup (net thread already logs the change at info) and "Widget finished" lines to `debug!`.
- Docs updated in `CLAUDE.md` (NVS table, remote `config` keys, `temp_sensor` module, engine telemetry note); ideas tracked in `IDEAS.md`.

The `.webp` widget idea is intentionally left as a future research spike — no code here.

## Testing

- `cargo build` (max7219) clean — only pre-existing dead-code warnings.
- `just test` — 27 host tests pass.