### PR TITLE
Limit GITHUB_TOKEN permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ on:
         required: false
         default: ""
 
+# Least-privilege default for all jobs; the release job opts up to
+# contents: write where it actually needs to publish.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build ${{ matrix.variant }}


### PR DESCRIPTION
Fixes the CodeQL code-scanning alert `actions/missing-workflow-permissions` (medium) at `.github/workflows/release.yml`.

The `build` job didn't constrain `GITHUB_TOKEN` and there was no workflow-level default. Added a top-level least-privilege default of `contents: read`. The `release` job keeps its existing `contents: write` override, which is the only job that needs to publish.

No functional change to the build or release behavior.