### PR TITLE
Fix NTP re-sync (#11) and add NTP server override (#12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ All config is loaded from the `kurokku` NVS namespace on boot. Unset keys fall b
 | `device_id` | string | `unprovisioned` | Device identifier for server API |
 | `tz` | string | `UTC0` | POSIX TZ string for local time |
 | `syslog_host` | string | (unset) | UDP syslog target as `host:port` |
+| `ntp_server` | string | (unset) | NTP server override; unset uses pool.ntp.org defaults |
 | `format_24h` | u8 (0/1) | `1` | 24-hour clock format |
 | `brightness` | u8 | `4` | Default display brightness 0-15 |
 | `poll_ms` | i32 | `5000` | Server poll interval in ms |

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,8 @@ pub struct AppConfig {
     pub syslog_host: Option<String>,
     /// Maximum log level: "off", "error", "warn", "info", "debug", or "trace".
     pub log_level: String,
+    /// NTP server override (host or IP). None = ESP-IDF's pool.ntp.org defaults.
+    pub ntp_server: Option<String>,
 }
 
 /// Parse a log level string into a `LevelFilter`. Unrecognized values (including
@@ -54,6 +56,7 @@ impl AppConfig {
         let tz = nvs_get_str(nvs, "tz").unwrap_or_else(|| "UTC0".to_string());
         let syslog_host = nvs_get_str(nvs, "syslog_host");
         let log_level = nvs_get_str(nvs, "log_level").unwrap_or_else(|| "info".to_string());
+        let ntp_server = nvs_get_str(nvs, "ntp_server");
 
         let cfg = Self {
             wifi_ssid,
@@ -66,10 +69,11 @@ impl AppConfig {
             tz,
             syslog_host,
             log_level,
+            ntp_server,
         };
 
         log::info!(
-            "Config loaded: server={}, device={}, 24h={}, brightness={}, poll={}ms, tz={}, syslog={:?}, log_level={}",
+            "Config loaded: server={}, device={}, 24h={}, brightness={}, poll={}ms, tz={}, syslog={:?}, log_level={}, ntp={:?}",
             cfg.server_url,
             cfg.device_id,
             cfg.format_24h,
@@ -78,6 +82,7 @@ impl AppConfig {
             cfg.tz,
             cfg.syslog_host,
             cfg.log_level,
+            cfg.ntp_server,
         );
 
         cfg
@@ -98,6 +103,12 @@ impl AppConfig {
             Some(h) => nvs_set_str(nvs, "syslog_host", h)?,
             None => {
                 let _ = nvs.remove("syslog_host");
+            }
+        }
+        match &self.ntp_server {
+            Some(s) => nvs_set_str(nvs, "ntp_server", s)?,
+            None => {
+                let _ = nvs.remove("ntp_server");
             }
         }
         log::info!("Config saved to NVS");

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,12 @@ fn run(
         let _ = status.run(&mut any_disp, &cancel);
     }
 
+    // The SNTP handle must outlive the engine: dropping it calls sntp_stop()
+    // and kills periodic re-sync, which strands the device on whatever time it
+    // had at boot. Held at function scope so it lives as long as eng.run()
+    // (which never returns). See issue #11.
+    let mut _sntp: Option<wifi::EspSntp> = None;
+
     let wifi_handle: Option<engine::SharedWifi> = if cfg.has_wifi_config() {
         match wifi::connect(&cfg.wifi_ssid, &cfg.wifi_password, modem, sysloop, nvs_partition) {
             Ok(w) => {
@@ -161,8 +167,9 @@ fn run(
                     udp_log::enable_udp(host, &cfg.device_id);
                 }
 
-                // Sync NTP — keep handle alive for periodic re-sync
-                let _sntp = match wifi::sync_ntp() {
+                // Sync NTP — handle is stored at function scope so periodic
+                // re-sync keeps running for the life of the engine (#11).
+                _sntp = match wifi::sync_ntp(cfg.ntp_server.as_deref()) {
                     Ok(sntp) => Some(sntp),
                     Err(e) => {
                         log::warn!("NTP sync failed: {}", e);

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -69,20 +69,41 @@ pub fn get_ip(wifi: &BlockingWifi<EspWifi<'static>>) -> Option<String> {
         .map(|info| format!("{}", info.ip))
 }
 
-/// Sync system time from NTP. Blocks until the first sync completes or timeout.
-/// Returns the SNTP handle — caller must keep it alive so periodic re-syncs
-/// continue (default: every hour via ESP-IDF's CONFIG_LWIP_SNTP_UPDATE_DELAY).
-pub fn sync_ntp() -> Result<EspSntp<'static>> {
-    use esp_idf_svc::sntp::EspSntp;
+/// Start SNTP and block until the first sync completes or a 15s timeout.
+///
+/// Returns the SNTP handle, which the caller **must keep alive for the lifetime
+/// of the program**: dropping it calls `sntp_stop()` and kills periodic re-sync
+/// (ESP-IDF re-syncs every hour by default via `CONFIG_LWIP_SNTP_UPDATE_DELAY`).
+///
+/// A timeout is *not* fatal — the returned handle keeps polling in the
+/// background, so a device that boots before its NTP server is reachable will
+/// still sync once the network recovers, instead of staying on a wrong time
+/// until reboot.
+///
+/// `ntp_server`, when set, overrides the primary pool server (NVS `ntp_server`).
+pub fn sync_ntp(ntp_server: Option<&str>) -> Result<EspSntp<'static>> {
+    use esp_idf_svc::sntp::{EspSntp, SntpConf};
 
-    log::info!("Starting NTP sync...");
-    let sntp = EspSntp::new_default()
-        .map_err(|e| anyhow::anyhow!("SNTP init failed: {}", e))?;
+    let mut conf = SntpConf::default();
+    match ntp_server.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(server) => {
+            // Override the primary server; any remaining slots keep their
+            // pool.ntp.org defaults as fallback (lwIP tries them in order).
+            conf.servers[0] = server;
+            log::info!("Starting NTP sync (server override: {})...", server);
+        }
+        None => log::info!("Starting NTP sync..."),
+    }
+
+    let sntp =
+        EspSntp::new(&conf).map_err(|e| anyhow::anyhow!("SNTP init failed: {}", e))?;
 
     let start = std::time::Instant::now();
     while sntp.get_sync_status() != esp_idf_svc::sntp::SyncStatus::Completed {
         if start.elapsed() > Duration::from_secs(15) {
-            anyhow::bail!("NTP sync timed out after 15s");
+            // Hand the still-running handle back so background re-sync continues.
+            log::warn!("NTP first sync not completed within 15s; continuing in background");
+            return Ok(sntp);
         }
         std::thread::sleep(Duration::from_millis(100));
     }

--- a/tools/devices/example.yaml
+++ b/tools/devices/example.yaml
@@ -13,3 +13,4 @@ tz: CST6CDT,M3.2.0,M11.1.0
 # brightness: 4             # 0-15, default 4
 # poll_ms: 5000             # default 5000
 # syslog_host: 192.168.1.50:5514   # omit to disable UDP syslog
+# ntp_server: pool.ntp.org  # omit to use ESP-IDF's pool.ntp.org defaults

--- a/tools/provision.py
+++ b/tools/provision.py
@@ -51,6 +51,7 @@ SCHEMA = {
     "device_id":   ("device_id",   "string"),
     "tz":          ("tz",          "string"),
     "syslog_host": ("syslog_host", "string"),
+    "ntp_server":  ("ntp_server",  "string"),
     "format_24h":  ("format_24h",  "u8"),
     "brightness":  ("brightness",  "u8"),
     # Firmware reads this via get_i32 + cast (esp-idf-svc's NVS wrapper


### PR DESCRIPTION
## #11 — NTP re-sync was dead

Root cause: the `EspSntp` handle from `sync_ntp()` was bound to a local `_sntp` **inside** the WiFi-connect block in `main()`, so it was dropped at the end of that block — before the engine even started. Dropping the handle calls `sntp_stop()`, so the device synced time **once at boot and never re-synced**. A device that drifted, or whose first sync was late/bad, stayed on the wrong time until a manual reboot. This matches the "weird time for quite some time" report.

Fixes:
- The handle now lives at `main()` scope, so it outlives `eng.run()` (which never returns) and ESP-IDF's hourly re-sync keeps running.
- `sync_ntp()` no longer discards the handle when the first sync is slow: on the 15s timeout it returns the *still-running* handle (logging a warning) instead of bailing, so background sync completes once the network recovers.

## #12 — NTP server override

New optional `ntp_server` NVS key (host or IP), wired through `config.rs`, `provision.py`, and `example.yaml`. When set, it replaces the primary `pool.ntp.org` server in `SntpConf`; unset keeps ESP-IDF's defaults. Applied at boot from NVS.

Note: the override is applied at boot only — a live remote-config restart of SNTP (parallel to how `tz`/`log_level` apply live) is a possible follow-up; it needs the SNTP handle to move into the engine.

Closes #11, closes #12.

Built clean for `riscv32imc-esp-espidf` (default `max7219` feature).